### PR TITLE
update openshift-nfd to sro

### DIFF
--- a/cr/nfd/nfd_cr.yaml
+++ b/cr/nfd/nfd_cr.yaml
@@ -3,11 +3,11 @@ apiVersion: nfd.openshift.io/v1
 kind: NodeFeatureDiscovery
 metadata:
   name: nfd-instance
-  namespace: openshift-nfd
+  namespace: sro
 spec:
   instance: "" # instance is empty by default
   operand:
-    namespace: openshift-nfd
+    namespace: sro
     image: quay.io/openshift/origin-node-feature-discovery:4.8
     imagePullPolicy: Always
   workerConfig:


### PR DESCRIPTION
address the fact that NFD is deployed in the same namespace as SRO
update CR to accommodate that
NOTE: This may change with adopting upstream 4.9 SRO (non-Silicom fork).