### PR TITLE
customize buildconfig name on per-kernel basis

### DIFF
--- a/charts/ice-special-resource-0.0.1/templates/0000-state-driver-buildconfig.yaml
+++ b/charts/ice-special-resource-0.0.1/templates/0000-state-driver-buildconfig.yaml
@@ -10,8 +10,8 @@ apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   labels:
-    app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverBuild}}
-  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverBuild}}
+    app: ice-build-{{ template "build.name" . }}
+  name: ice-build-{{ template "build.name" . }}
   namespace: {{.Values.specialresource.spec.namespace}}
   annotations:
     specialresource.openshift.io/wait: "true"
@@ -60,7 +60,6 @@ spec:
           value: {{ $arg.value }}
         {{- end }}
         - name: BUILD_BASE
-#          value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aea6d1e324558e2484bb14d6ffb8455fc752628c12118e8f33c8ae0a31990e06
           value: {{.Values.driverToolkitImage}}
   output:
     to:

--- a/charts/ice-special-resource-0.0.1/templates/templates/_helpers.tpl
+++ b/charts/ice-special-resource-0.0.1/templates/templates/_helpers.tpl
@@ -1,0 +1,4 @@
+/* name for buildconfig */
+{{- define "build.name" -}}
+{{- default "buildAkernel" .Values.kernelFullVersion | trunc 63 | trimSuffix "-" | trimSuffix "." | replace "_" "a"| lower -}}
+{{- end -}}


### PR DESCRIPTION
- Scale the installation of OOT drivers to multiple kernels by generating a different buildconfig object

- Take a look at the helpers to check how we can customiz the name of the build (we can do it better probably)

- Important to take out the "_" characters to be accepted (it needs to be  lowercase RFC 1123 subdomain)